### PR TITLE
fix(LookingGlassXRWebGLLayer): blit from renderable framebuffer when mismatched

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>@looking-glass/webxr - nullable framebuffer demo</title>
+    <style>
+      body {
+        margin: 0;
+      }
+
+      canvas {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module">
+      import * as THREE from 'three';
+      import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+      import { LookingGlassWebXRPolyfill, LookingGlassConfig } from '@lookingglass/webxr';
+
+      const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+      renderer.xr.enabled = true;
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      document.body.appendChild(renderer.domElement);
+
+      const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight);
+      camera.position.set(0, 1.3, 3);
+
+      const config = LookingGlassConfig;
+      config.tileHeight = 512;
+      config.numViews = 45;
+      config.targetY = 0;
+      config.targetZ = 0;
+      config.targetDiam = 3;
+      config.fovy = camera.fov * (Math.PI / 180);
+      config.inlineView = 2;
+      new LookingGlassWebXRPolyfill();
+
+      document.body.appendChild(VRButton.createButton(renderer));
+
+      const scene = new THREE.Scene();
+
+      scene.add(new THREE.GridHelper());
+      scene.add(new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshNormalMaterial()));
+
+      window.addEventListener('resize', () => {
+        renderer.setSize(window.innerWidth, window.innerHeight)
+        camera.aspect = window.innerWidth / window.innerHeight
+        camera.updateProjectionMatrix()
+      })
+
+      renderer.setAnimationLoop(() => {
+        // Uncomment this line to reproduce
+        renderer.setRenderTarget(null);
+
+        renderer.render(scene, camera);
+      });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "url": "git+https://github.com/Looking-Glass/looking-glass-webxr.git"
   },
   "scripts": {
+    "dev": "vite",
     "build": "vite build"
   },
   "devDependencies": {
+    "three": "^0.145.0",
     "vite": "^3.1.2"
   },
   "dependencies": {

--- a/src/LookingGlassXRWebGLLayer.js
+++ b/src/LookingGlassXRWebGLLayer.js
@@ -15,6 +15,7 @@
  */
 
  import XRWebGLLayer, { PRIVATE as XRWebGLLayer_PRIVATE } from '@lookingglass/webxr-polyfill/src/api/XRWebGLLayer';
+ import _global from '@lookingglass/webxr-polyfill/src/lib/global';
  import getLookingGlassConfig from './LookingGlassConfig';
  import { makeControls } from './LookingGlassControls';
  import { Shader } from 'holoplay-core';
@@ -217,6 +218,28 @@
        const oldRenderbufferBinding = gl.getParameter(gl.RENDERBUFFER_BINDING);
        const oldProgram = gl.getParameter(gl.CURRENT_PROGRAM);
        const oldActiveTexture = gl.getParameter(gl.ACTIVE_TEXTURE);
+ 
+       // Copy to layer framebuffer when targets mismatch
+       const isWebGL2 = gl instanceof _global.WebGL2RenderingContext
+       if (isWebGL2 && oldFramebufferBinding !== this.framebuffer) {
+         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, oldFramebufferBinding)
+         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this.framebuffer);;
+         gl.blitFramebuffer(
+           0,
+           0,
+           gl.drawingBufferWidth,
+           gl.drawingBufferHeight,
+           0,
+           0,
+           gl.drawingBufferWidth,
+           gl.drawingBufferHeight,
+           gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT,
+           gl.NEAREST,
+         );
+         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+       }
+ 
        {
          const oldTextureBinding = gl.getParameter(gl.TEXTURE_BINDING_2D);
          {

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,11 +2,18 @@ import { resolve } from 'path'
 import path from 'path'
 import { defineConfig } from 'vite'
 
+const entry = resolve(__dirname, 'src/LookingGlassWebXRPolyfill.js')
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@lookingglass/webxr': entry
+    }
+  },
   build: {
     minify: true,
     lib: {
-      entry: resolve(__dirname, 'src/LookingGlassWebXRPolyfill.js'),
+      entry,
       name: 'Looking Glass WebXR',
       // the proper extensions will be added
       fileName: '@lookingglass/webxr'


### PR DESCRIPTION
Whenever `gl.bindFramebuffer` is nulled to render to the default canvas FBO, the immersive WebXR popup window results in a black, cleared canvas.

I've committed a local reproduction case based on [this gist](https://gist.github.com/CodyJasonBennett/c08227609ae0a12e29c68753dcf0e9ec) for iteration. There are some withstanding issues with the debug canvas sizing and blurriness in the WebXR preview, so I'm keeping this as a draft for the moment.