### PR TITLE
feat: forward events from WebXR canvas to DOM canvas

### DIFF
--- a/src/LookingGlassEventBridge.js
+++ b/src/LookingGlassEventBridge.js
@@ -1,0 +1,92 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement#events
+export const DOM_EVENTS = [
+  // ClipboardEvent
+  'copy',
+  'cut',
+  'paste',
+  'invalid',
+  // AnimationEvent
+  'animationcancel',
+  'animationend',
+  'animationiteration',
+  'animationstart',
+  // InputEvent
+  'beforeinput',
+  'input',
+  'change',
+  // PointerEvent
+  'gotpointercapture',
+  'lostpointercapture',
+  'pointercancel',
+  'pointerdown',
+  'pointerenter',
+  'pointerleave',
+  'pointermove',
+  'pointerout',
+  'pointerover',
+  'pointerup',
+  // MouseEvent
+  'click',
+  'dblclick',
+  'mousedown',
+  'mouseenter',
+  'mouseleave',
+  'mousemove',
+  'mouseover',
+  'mouseout',
+  'mouseup',
+  // Wheel Event
+  'mousewheel',
+  'wheel',
+  // TouchEvent
+  'touchcancel',
+  'touchend',
+  'touchmove',
+  'touchstart',
+  // DragEvent
+  'drag',
+  'dragend',
+  'dragenter',
+  'dragleave',
+  'dragover',
+  'dragstart',
+  'drop',
+  // TransitionEvent
+  'transitioncancel',
+  'transitionend',
+  'transitionrun',
+  'transitionstart',
+  // FocusEvent
+  'blur',
+  'focus',
+  'focusin',
+  'focusout',
+  // KeyboardEvent
+  'keydown',
+  'keypress',
+  'keyup',
+  // Event
+  'fullscreenchange',
+  'fullscreenerror'
+];
+
+/**
+ * Forwards DOM events between two elements.
+ */
+export function forwardEvents(sourceElement, targetElement) {
+  // Binds bridge listeners
+  const listeners = new Map();
+  for (const type of DOM_EVENTS) {
+    const listener = (event) => targetElement.dispatchEvent(new event.constructor(event.type, event));
+    sourceElement.addEventListener(type, listener);
+    listeners.set(type, listener);
+  }
+
+  // Returns a cleanup function to unbind listeners
+  return () => {
+    for (const [type, listener] of listeners) {
+      sourceElement.removeEventListener(type, listener);
+      listeners.delete(type);
+    }
+  };
+}

--- a/src/LookingGlassXRDevice.js
+++ b/src/LookingGlassXRDevice.js
@@ -165,7 +165,9 @@ export default class LookingGlassXRDevice extends XRDevice {
   endSession(sessionId) {
     const session = this.sessions.get(sessionId);
     if (session.immersive && session.baseLayer) {
-      session.baseLayer[LookingGlassXRWebGLLayer_PRIVATE].moveCanvasToWindow(false);
+      const baseLayerPrivate = session.baseLayer[LookingGlassXRWebGLLayer_PRIVATE];
+      baseLayerPrivate.moveCanvasToWindow(false);
+      baseLayerPrivate.disposeEventBridge();
       this.dispatchEvent('@@webxr-polyfill/vr-present-end', sessionId);
     }
     session.ended = true;

--- a/src/LookingGlassXRWebGLLayer.js
+++ b/src/LookingGlassXRWebGLLayer.js
@@ -17,6 +17,7 @@
  import XRWebGLLayer, { PRIVATE as XRWebGLLayer_PRIVATE } from '@lookingglass/webxr-polyfill/src/api/XRWebGLLayer';
  import getLookingGlassConfig from './LookingGlassConfig';
  import { makeControls } from './LookingGlassControls';
+ import { forwardEvents } from './LookingGlassEventBridge';
  import { Shader } from 'holoplay-core';
  
  export const PRIVATE = Symbol('LookingGlassXRWebGLLayer');
@@ -33,6 +34,9 @@
        this.requestFullscreen();
      });
      const controls = makeControls(lkgCanvas);
+
+     const appCanvas = gl.canvas;
+     const disposeEventBridge = forwardEvents(lkgCanvas, appCanvas);
  
      const cfg = getLookingGlassConfig();
  
@@ -188,8 +192,6 @@
        gl.clearStencil(currentClearStencil);
      };
  
-     const appCanvas = gl.canvas;
- 
      let origWidth, origHeight;
  
      const blitTextureToDefaultFramebufferIfNeeded = () => {
@@ -306,6 +308,7 @@
      this[PRIVATE] = {
        LookingGlassEnabled: false,
        framebuffer,
+       disposeEventBridge,
        clearFramebuffer,
        blitTextureToDefaultFramebufferIfNeeded,
        moveCanvasToWindow,


### PR DESCRIPTION
Forwards DOM events from the popup WebXR canvas to the debug DOM canvas.

> **Note**: each canvas' events have their own state, so pointer-lock shouldn't cause event collisions.