### PR TITLE
Fix entry points in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/webxr.umd.cjs",
-  "module": "./dist/webxr.js",
+  "main": "./dist/@lookingglass/webxr.umd.cjs",
+  "module": "./dist/@lookingglass/webxr.js",
   "exports": {
     ".": {
       "import": "./dist/@lookingglass/webxr.js",


### PR DESCRIPTION
The "main" and "module" entry points seemed to be out of date in the package.json causing this to break in parcel.