### PR TITLE
Bug fixes and performance improvements: texture slot overwrite and unnecessary framebuffer allocation

### DIFF
--- a/src/LookingGlassXRWebGLLayer.ts
+++ b/src/LookingGlassXRWebGLLayer.ts
@@ -71,8 +71,11 @@ export default class LookingGlassXRWebGLLayer extends XRWebGLLayer {
 			depthStencil = gl.createRenderbuffer()
 		}
 		// utility functions for allocating the framebuffer resources
-
+		let allocatedFramebufferWidth = NaN
+		let allocatedFramebufferHeight = NaN
 		const allocateFramebufferAttachments = (gl, texture, depthStencil, dsConfig, cfg) => {
+			allocatedFramebufferWidth = cfg.framebufferWidth
+			allocatedFramebufferHeight = cfg.framebufferHeight
 			allocateTexture(gl, texture, cfg.framebufferWidth, cfg.framebufferHeight)
 			if (depthStencil) {
 				allocateDepthStencil(gl, depthStencil, dsConfig, cfg.framebufferWidth, cfg.framebufferHeight)
@@ -102,10 +105,19 @@ export default class LookingGlassXRWebGLLayer extends XRWebGLLayer {
 				gl.framebufferRenderbuffer(gl.FRAMEBUFFER, dsConfig.attachment, gl.RENDERBUFFER, depthStencil)
 			}
 			gl.bindFramebuffer(gl.FRAMEBUFFER, oldFramebufferBinding)
+			console.log(performance.now().toFixed(2), 'setupFramebuffer', oldFramebufferBinding);
 		}
 
 		allocateFramebufferAttachments(gl, texture, depthStencil, dsConfig, cfg)
-		cfg.addEventListener("on-config-changed", () => allocateFramebufferAttachments(gl, texture, depthStencil, dsConfig, cfg))
+		cfg.addEventListener("on-config-changed", () => {
+			// only reallocate textures if framebuffer size has changed
+			if (
+				cfg.framebufferWidth !== allocatedFramebufferWidth ||
+				cfg.framebufferHeight !== allocatedFramebufferHeight
+			) {
+				allocateFramebufferAttachments(gl, texture, depthStencil, dsConfig, cfg)
+			}
+		});
 
 		setupFramebuffer(gl, framebuffer, texture, dsConfig, depthStencil, config)
 

--- a/src/LookingGlassXRWebGLLayer.ts
+++ b/src/LookingGlassXRWebGLLayer.ts
@@ -291,8 +291,12 @@ export default class LookingGlassXRWebGLLayer extends XRWebGLLayer {
 		// Utility functions to handle WebGL state
 
 		function restoreWebGLState(oldState) {
+			// restore texture slot 0 binding
+			gl.activeTexture(gl.TEXTURE0)
+			gl.bindTexture(gl.TEXTURE_2D, oldState.texture0Binding)
+
+			// restore previously active texture slot
 			gl.activeTexture(oldState.activeTexture)
-			gl.bindTexture(gl.TEXTURE_2D, oldState.textureBinding)
 			gl.useProgram(oldState.program)
 			gl.bindRenderbuffer(gl.RENDERBUFFER, oldState.renderbufferBinding)
 			gl.bindFramebuffer(gl.FRAMEBUFFER, oldState.framebufferBinding)
@@ -336,7 +340,13 @@ export default class LookingGlassXRWebGLLayer extends XRWebGLLayer {
 		 * @returns {Object} The current WebGL state
 		 */
 		function saveWebGLState() {
-			return {
+			// save the currently active texture slot
+			let activeTextureSlot = gl.getParameter(gl.ACTIVE_TEXTURE);
+			// save the texture in slot 0, since we will overwrite it
+			gl.activeTexture(gl.TEXTURE0);
+			let texture0Binding = gl.getParameter(gl.TEXTURE_BINDING_2D);
+
+			let state = {
 				VAO: gl.getParameter(gl.VERTEX_ARRAY_BINDING),
 				cullFace: gl.getParameter(gl.CULL_FACE),
 				blend: gl.getParameter(gl.BLEND),
@@ -347,9 +357,11 @@ export default class LookingGlassXRWebGLLayer extends XRWebGLLayer {
 				framebufferBinding: gl.getParameter(gl.FRAMEBUFFER_BINDING),
 				renderbufferBinding: gl.getParameter(gl.RENDERBUFFER_BINDING),
 				program: gl.getParameter(gl.CURRENT_PROGRAM),
-				activeTexture: gl.getParameter(gl.ACTIVE_TEXTURE),
-				textureBinding: gl.getParameter(gl.TEXTURE_BINDING_2D),
+				activeTexture: activeTextureSlot, // active texture slot
+				texture0Binding: texture0Binding,
 			}
+
+			return state;
 		}
 		/**
 		 * Set up the WebGL state for rendering

--- a/src/LookingGlassXRWebGLLayer.ts
+++ b/src/LookingGlassXRWebGLLayer.ts
@@ -105,7 +105,6 @@ export default class LookingGlassXRWebGLLayer extends XRWebGLLayer {
 				gl.framebufferRenderbuffer(gl.FRAMEBUFFER, dsConfig.attachment, gl.RENDERBUFFER, depthStencil)
 			}
 			gl.bindFramebuffer(gl.FRAMEBUFFER, oldFramebufferBinding)
-			console.log(performance.now().toFixed(2), 'setupFramebuffer', oldFramebufferBinding);
 		}
 
 		allocateFramebufferAttachments(gl, texture, depthStencil, dsConfig, cfg)


### PR DESCRIPTION
- Fix issue where texture in slot 0 was not restored:

At the end of a frame we change gl state while allocating and blitting to framebuffer. When saving state, we previously saved the current active texture slot and the texture bound in that slot. Then we changed to slot 0, overwrite the texture and restore the previously active texture slot. The problem here is: say slot `2` was bound then we have
```js
let savedTextureSlot = 2
let savedTexture = ...

activeTexture(0)
bindTexture(<some-texture>)

activeTexture(2)
bindTexture(savedTexture)
```
Notice we changed the texture in slot 0 without restoring its value

- Fix issue where a new framebuffer is allocated nearly every frame:

We were calling `allocateFramebufferAttachments` for `on-config-changed`, since CFG holds so many parameters, it was changing each frame with just the camera changes. Now we check just if the framebuffer size changes before allocating

Repro:

Replace the cube in the three.js example with
```js
let textureCanvas = document.createElement("canvas")
textureCanvas.width = 256
textureCanvas.height = 256
let ctx = textureCanvas.getContext("2d")
ctx.fillStyle = "white"
ctx.fillRect(0, 0, 256, 256)
ctx.fillStyle = "black"
ctx.fillRect(0, 0, 128, 128)
ctx.fillRect(128, 128, 128, 128)
let texture = new THREE.CanvasTexture(textureCanvas)

const cube = new THREE.Mesh(new THREE.BoxGeometry(2, 0.1, 0.1), new THREE.MeshPhysicalMaterial({
	color: "red",
	map: texture,
	// set roughness map to texture
	roughnessMap: texture,
	// set metalness map to texture
	metalnessMap: texture,
}))
```

This uses 3 texture slots

When going into XR mode, the rendering breaks with WebGL errors (framebuffer texture gets bound to slot 0)